### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-dotnet@v3.0.3
+        with:
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
       - run: dotnet restore
-
-      - name: Build
-        run: >
-          dotnet build
-          --configuration Release
-          --no-restore
-          /warnAsError
-          /nologo
-          /clp:NoSummary
+      - run: dotnet build --configuration Release --no-restore /warnAsError /nologo /clp:NoSummary
 
       - name: Run Tests
         run: >
@@ -47,16 +45,26 @@ jobs:
           Paperless__BaseAddress: 'https://localhost:5002/'
           Paperless__Token: 'token'
 
-      - name: ReSharper annotations
-        uses: VMelnalksnis/resharper-inspect-action@v0.2.5
-        with:
-          solution: PaperlessDotNet.sln
-          resharper-version: 2022.1.2
-          treat-warnings-as-errors: true
-
       - name: Gather Code Coverage
         if: github.event.schedule == null
         uses: codecov/codecov-action@v3.1.1
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          
+  resharper:
+    name: Resharper
+    runs-on: ubuntu-latest
+    if: false #ReSharper currently does not support .NET 7
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-dotnet@v3.0.3
+      - run: dotnet restore
+      - run: dotnet build --configuration Release --no-restore /warnAsError /nologo /clp:NoSummary
+
+      - name: ReSharper annotations
+        uses: VMelnalksnis/resharper-inspect-action@v0.2.5
+        with:
+          solution: PaperlessDotNet.sln
+          resharper-version: 2022.1.2
+          treat-warnings-as-errors: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<DebugType>portable</DebugType>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,9 @@
 		<PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1"/>
 		<PackageVersion Include="DotNet.ReproducibleBuilds.Isolated" Version="1.1.1"/>
 		<PackageVersion Include="FluentAssertions" Version="6.8.0"/>
+		<PackageVersion Include="IsExternalInit" Version="1.0.3"/>
 		<PackageVersion Include="Jetbrains.Annotations" Version="2022.3.1"/>
+		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0"/>
 		<PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
 		<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0"/>
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
@@ -16,11 +18,13 @@
 		<PackageVersion Include="NodaTime" Version="3.1.5"/>
 		<PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0"/>
 		<PackageVersion Include="NodaTime.Testing" Version="3.1.5"/>
+		<PackageVersion Include="Nullable" Version="1.3.1"/>
 		<PackageVersion Include="Serilog" Version="2.12.0"/>
 		<PackageVersion Include="Serilog.AspNetCore" Version="6.0.1"/>
 		<PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.3"/>
 		<PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
 		<PackageVersion Include="System.Net.Http" Version="4.3.4"/>
+		<PackageVersion Include="System.Net.Http.Json" Version="7.0.0"/>
 		<PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
 		<PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435"/>
 		<PackageVersion Include="xunit" Version="2.4.2"/>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "6.0.400",
+		"version": "7.0.100",
 		"rollForward": "latestFeature",
 		"allowPrerelease": false
 	}

--- a/source/VMelnalksnis.PaperlessDotNet.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/source/VMelnalksnis.PaperlessDotNet.DependencyInjection/ServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +14,10 @@ using Microsoft.Extensions.Options;
 using VMelnalksnis.PaperlessDotNet.Correspondents;
 using VMelnalksnis.PaperlessDotNet.Documents;
 using VMelnalksnis.PaperlessDotNet.Serialization;
+
+#if NET6_0_OR_GREATER
+using System.Net.Mime;
+#endif
 
 namespace VMelnalksnis.PaperlessDotNet.DependencyInjection;
 
@@ -34,7 +37,11 @@ public static class ServiceCollectionExtensions
 	/// <param name="serviceCollection">The service collection in which to register the services.</param>
 	/// <param name="configuration">The configuration to which to bind options models.</param>
 	/// <returns>The <see cref="IHttpClientBuilder"/> for the <see cref="HttpClient"/> used by <see cref="IPaperlessClient"/>.</returns>
+#if NET6_0_OR_GREATER
 	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = $"{nameof(PaperlessOptions)} contains only system types.")]
+#else
+	[SuppressMessage("Trimming", "IL2026", Justification = $"{nameof(PaperlessOptions)} contains only system types.")]
+#endif
 	public static IHttpClientBuilder AddPaperlessDotNet(
 		this IServiceCollection serviceCollection,
 		IConfiguration configuration)
@@ -65,7 +72,11 @@ public static class ServiceCollectionExtensions
 
 				client.BaseAddress = options.BaseAddress;
 				client.DefaultRequestHeaders.UserAgent.Add(_userAgent);
+#if NET6_0_OR_GREATER
 				client.DefaultRequestHeaders.Add("Accept", $"{MediaTypeNames.Application.Json}; version=2");
+#else
+				client.DefaultRequestHeaders.Add("Accept", "application/json; version=2");
+#endif
 				client.DefaultRequestHeaders.Authorization = new("Token", options.Token);
 			});
 	}

--- a/source/VMelnalksnis.PaperlessDotNet.DependencyInjection/VMelnalksnis.PaperlessDotNet.DependencyInjection.csproj
+++ b/source/VMelnalksnis.PaperlessDotNet.DependencyInjection/VMelnalksnis.PaperlessDotNet.DependencyInjection.csproj
@@ -26,4 +26,15 @@
 		<PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="IsExternalInit">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Nullable">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
 </Project>

--- a/source/VMelnalksnis.PaperlessDotNet/VMelnalksnis.PaperlessDotNet.csproj
+++ b/source/VMelnalksnis.PaperlessDotNet/VMelnalksnis.PaperlessDotNet.csproj
@@ -19,6 +19,11 @@
 		<PackageReference Include="NodaTime" />
 		<PackageReference Include="NodaTime.Serialization.SystemTextJson" />
 	</ItemGroup>
+	
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+		<PackageReference Include="System.Net.Http.Json" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,9 +2,12 @@
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
 	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 		<IsTrimmable>false</IsTrimmable>
 		<EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+		<NoWarn>NETSDK1138</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/VMelnalksnis.PaperlessDotNet.Tests.Integration/VMelnalksnis.PaperlessDotNet.Tests.Integration.csproj
+++ b/tests/VMelnalksnis.PaperlessDotNet.Tests.Integration/VMelnalksnis.PaperlessDotNet.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-	  <UserSecretsId>20e7c251-0bc2-4764-b533-448d014f1212</UserSecretsId>
+		<UserSecretsId>20e7c251-0bc2-4764-b533-448d014f1212</UserSecretsId>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
* Target .NET Standard 2.0
* Test all .NET Core versions from 3.1
* Split tests and resharper in separate jobs
