### PR TITLE
Increase default task polling delay in order to avoid Paperless concurrency issues when creating documents

### DIFF
--- a/source/VMelnalksnis.PaperlessDotNet/PaperlessOptions.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/PaperlessOptions.cs
@@ -23,5 +23,5 @@ public sealed class PaperlessOptions
 
 	/// <summary> Gets or sets the time delay between each polling of tasks in milliseconds.</summary>
 	[Required]
-	public TimeSpan TaskPollingDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+	public TimeSpan TaskPollingDelay { get; set; } = TimeSpan.FromMilliseconds(250);
 }


### PR DESCRIPTION
Fixes #284