### PR TITLE
Add ability to retrieve all documents associated with a specific tag ID

### DIFF
--- a/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
@@ -49,6 +49,12 @@ public sealed class DocumentClient : IDocumentClient
 	{
 		return GetAllCore<Document>(Routes.Documents.Uri, cancellationToken);
 	}
+	
+	/// <inheritdoc />
+	public IAsyncEnumerable<Document> GetAllByTagId(int a_TagId,CancellationToken cancellationToken = default)
+	{
+		return GetAllCore<Document>(Routes.Documents.ByTagIdUri(a_TagId), cancellationToken);
+	}
 
 	/// <inheritdoc />
 	public async IAsyncEnumerable<Document<TFields>> GetAll<TFields>([EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
@@ -53,7 +53,7 @@ public sealed class DocumentClient : IDocumentClient
 	/// <summary>
 	/// Gets all documents tagged with a certain tag Id.
 	/// </summary>
-	/// <param name="tagId">Id of the tag for which to retrieve documents.</param>
+	/// <param name="tagId">Id of the tag for which to retrieve all documents.</param>
 	/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
 	/// <returns>An enumerable which will asynchronously iterate over all retrieved documents.</returns>
 	public IAsyncEnumerable<Document> GetAllByTagId(int tagId, CancellationToken cancellationToken = default)

--- a/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
@@ -49,11 +49,16 @@ public sealed class DocumentClient : IDocumentClient
 	{
 		return GetAllCore<Document>(Routes.Documents.Uri, cancellationToken);
 	}
-	
-	/// <inheritdoc />
-	public IAsyncEnumerable<Document> GetAllByTagId(int a_TagId,CancellationToken cancellationToken = default)
+
+	/// <summary>
+	/// Gets all documents tagged with a certain tag Id.
+	/// </summary>
+	/// <param name="tagId">Id of the tag for which to retrieve documents.</param>
+	/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+	/// <returns>An enumerable which will asynchronously iterate over all retrieved documents.</returns>
+	public IAsyncEnumerable<Document> GetAllByTagId(int tagId, CancellationToken cancellationToken = default)
 	{
-		return GetAllCore<Document>(Routes.Documents.ByTagIdUri(a_TagId), cancellationToken);
+		return GetAllCore<Document>(Routes.Documents.ByTagIdUri(tagId), cancellationToken);
 	}
 
 	/// <inheritdoc />

--- a/source/VMelnalksnis.PaperlessDotNet/Routes.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Routes.cs
@@ -40,6 +40,8 @@ internal static class Routes
 		internal static readonly Uri CreateUri = new($"{_documents}post_document/", Relative);
 
 		internal static Uri IdUri(int id) => new($"{_documents}{id}/", Relative);
+		
+		internal static Uri ByTagIdUri(int id) => new($"{_documents}?tags__id__all={id}", Relative);
 
 		internal static Uri MetadataUri(int id) => new($"{_documents}{id}/metadata/", Relative);
 

--- a/source/VMelnalksnis.PaperlessDotNet/Routes.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Routes.cs
@@ -40,7 +40,7 @@ internal static class Routes
 		internal static readonly Uri CreateUri = new($"{_documents}post_document/", Relative);
 
 		internal static Uri IdUri(int id) => new($"{_documents}{id}/", Relative);
-		
+
 		internal static Uri ByTagIdUri(int id) => new($"{_documents}?tags__id__all={id}", Relative);
 
 		internal static Uri MetadataUri(int id) => new($"{_documents}{id}/metadata/", Relative);


### PR DESCRIPTION
Introduced `GetAllByTagId` in `DocumentClient` to retrieve documents associated with a specific tag ID. Added a corresponding URI generator `ByTagIdUri` in the `Routes` class for constructing the API endpoint.

Fixes # .

Changes proposed in this pull request:
* 
