### PR TITLE
feat: Add method to fetch documents by tag ID

### DIFF
--- a/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
@@ -90,6 +90,17 @@ public sealed class DocumentClient : IDocumentClient
 		}
 	}
 
+	/// <summary>
+	/// Gets all documents tagged with a certain tag Id.
+	/// </summary>
+	/// <param name="tagId">Id of the tag for which to retrieve all documents.</param>
+	/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+	/// <returns>An enumerable which will asynchronously iterate over all retrieved documents.</returns>
+	public IAsyncEnumerable<Document> GetAllByTagId(int tagId, CancellationToken cancellationToken = default)
+	{
+		return GetAllCore<Document>(Routes.Documents.ByTagIdUri(tagId), cancellationToken);
+	}
+
 	/// <inheritdoc />
 	public Task<Document?> Get(int id, CancellationToken cancellationToken = default)
 	{

--- a/source/VMelnalksnis.PaperlessDotNet/Routes.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Routes.cs
@@ -39,6 +39,8 @@ internal static class Routes
 		internal static readonly Uri Uri = new(_documents, Relative);
 		internal static readonly Uri CreateUri = new($"{_documents}post_document/", Relative);
 
+		internal static Uri ByTagIdUri(int id) => new($"{_documents}?tags__id__all={id}", Relative);
+
 		internal static Uri IdUri(int id) => new($"{_documents}{id}/", Relative);
 
 		internal static Uri MetadataUri(int id) => new($"{_documents}{id}/metadata/", Relative);


### PR DESCRIPTION
Addded Feature: allow for retrieval of documents by tag id.

Changes proposed in this pull request:
- Introduces the ability to fetch documents by their associated tag ID in a project. It adds a new public method `GetAllByTagId` in the `DocumentClient` class
