### PR TITLE
feat(api): add Update methods for tags and correspondents

### DIFF
--- a/source/VMelnalksnis.PaperlessDotNet/Correspondents/Correspondent.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Correspondents/Correspondent.cs
@@ -1,6 +1,8 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
 
 using NodaTime;
 
@@ -19,6 +21,7 @@ public sealed class Correspondent
 	public string Name { get; set; } = null!;
 
 	/// <summary>Gets or sets the pattern by which to match the correspondent to documents.</summary>
+	[JsonPropertyName("match")]
 	public string MatchingPattern { get; set; } = null!;
 
 	/// <summary>Gets or sets the id of the matching algorithm used to match the correspondent to documents.</summary>

--- a/source/VMelnalksnis.PaperlessDotNet/Correspondents/CorrespondentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Correspondents/CorrespondentClient.cs
@@ -61,15 +61,14 @@ public sealed class CorrespondentClient : ICorrespondentClient
 	}
 
 	/// <inheritdoc />
-	public async Task<Correspondent> Update(int id, CorrespondentUpdate update, CancellationToken cancellationToken = default)
+	public Task<Correspondent> Update(int id, CorrespondentUpdate update, CancellationToken cancellationToken = default)
 	{
-		using var response = await _httpClient
-			.PatchAsJsonAsync(Routes.Correspondents.IdUri(id), update, _options.GetTypeInfo<CorrespondentUpdate>())
-			.ConfigureAwait(false);
-
-		await response.EnsureSuccessStatusCodeAsync().ConfigureAwait(false);
-
-		return (await response.Content.ReadFromJsonAsync(_options.GetTypeInfo<Correspondent>(), cancellationToken).ConfigureAwait(false))!;
+		return _httpClient.PatchAsJsonAsync(
+			Routes.Correspondents.IdUri(id),
+			update,
+			_options.GetTypeInfo<CorrespondentUpdate>(),
+			_options.GetTypeInfo<Correspondent>(),
+			cancellationToken);
 	}
 
 	/// <inheritdoc />

--- a/source/VMelnalksnis.PaperlessDotNet/Correspondents/CorrespondentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Correspondents/CorrespondentClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -58,6 +58,18 @@ public sealed class CorrespondentClient : ICorrespondentClient
 			correspondent,
 			_options.GetTypeInfo<CorrespondentCreation>(),
 			_options.GetTypeInfo<Correspondent>());
+	}
+
+	/// <inheritdoc />
+	public async Task<Correspondent> Update(int id, CorrespondentUpdate update, CancellationToken cancellationToken = default)
+	{
+		using var response = await _httpClient
+			.PatchAsJsonAsync(Routes.Correspondents.IdUri(id), update, _options.GetTypeInfo<CorrespondentUpdate>())
+			.ConfigureAwait(false);
+
+		await response.EnsureSuccessStatusCodeAsync().ConfigureAwait(false);
+
+		return (await response.Content.ReadFromJsonAsync(_options.GetTypeInfo<Correspondent>(), cancellationToken).ConfigureAwait(false))!;
 	}
 
 	/// <inheritdoc />

--- a/source/VMelnalksnis.PaperlessDotNet/Correspondents/CorrespondentUpdate.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Correspondents/CorrespondentUpdate.cs
@@ -1,0 +1,24 @@
+// Copyright 2022 Valters Melnalksnis
+// Licensed under the Apache License 2.0.
+// See LICENSE file in the project root for full license information.
+
+namespace VMelnalksnis.PaperlessDotNet.Correspondents;
+
+/// <summary>Information needed to update a <see cref="Correspondent"/>.</summary>
+public sealed class CorrespondentUpdate
+{
+	/// <inheritdoc cref="Correspondent.Name"/>
+	public string? Name { get; set; }
+
+	/// <inheritdoc cref="Correspondent.MatchingPattern"/>
+	public string? Match { get; set; }
+
+	/// <inheritdoc cref="Correspondent.MatchingAlgorithm"/>
+	public MatchingAlgorithm? MatchingAlgorithm { get; set; }
+
+	/// <inheritdoc cref="Correspondent.IsInsensitive"/>
+	public bool? IsInsensitive { get; set; }
+
+	/// <summary>Gets or sets the id of the owner of the correspondent.</summary>
+	public int? Owner { get; set; }
+}

--- a/source/VMelnalksnis.PaperlessDotNet/Correspondents/ICorrespondentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Correspondents/ICorrespondentClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -32,6 +32,13 @@ public interface ICorrespondentClient
 	/// <param name="correspondent">The correspondent to create.</param>
 	/// <returns>The created correspondent.</returns>
 	Task<Correspondent> Create(CorrespondentCreation correspondent);
+
+	/// <summary>Updates an existing correspondent.</summary>
+	/// <param name="id">The id of the correspondent to update.</param>
+	/// <param name="update">The update to apply.</param>
+	/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+	/// <returns>The updated correspondent.</returns>
+	Task<Correspondent> Update(int id, CorrespondentUpdate update, CancellationToken cancellationToken = default);
 
 	/// <summary>Deletes a correspondent.</summary>
 	/// <param name="id">The id of the correspondent to delete.</param>

--- a/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Documents/DocumentClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -319,17 +319,15 @@ public sealed class DocumentClient : IDocumentClient
 			cancellationToken);
 	}
 
-	private async Task<TDocument> UpdateCore<TDocument, TUpdate>(int id, TUpdate update)
+	private Task<TDocument> UpdateCore<TDocument, TUpdate>(int id, TUpdate update)
 		where TDocument : Document
 		where TUpdate : DocumentUpdate
 	{
-		using var response = await _httpClient
-			.PatchAsJsonAsync(Routes.Documents.IdUri(id), update, _options.GetTypeInfo<TUpdate>())
-			.ConfigureAwait(false);
-
-		await response.EnsureSuccessStatusCodeAsync().ConfigureAwait(false);
-
-		return (await response.Content.ReadFromJsonAsync(_options.GetTypeInfo<TDocument>()).ConfigureAwait(false))!;
+		return _httpClient.PatchAsJsonAsync(
+			Routes.Documents.IdUri(id),
+			update,
+			_options.GetTypeInfo<TUpdate>(),
+			_options.GetTypeInfo<TDocument>());
 	}
 
 	private async Task<DocumentContent> DownloadContentCore(Uri requestUri, CancellationToken cancellationToken = default)

--- a/source/VMelnalksnis.PaperlessDotNet/Serialization/HttpClientExtensions.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Serialization/HttpClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -88,6 +88,22 @@ internal static class HttpClientExtensions
 #else
 		return httpClient.PatchAsync(requestUri, content);
 #endif
+	}
+
+	internal static async Task<TResponse> PatchAsJsonAsync<TRequest, TResponse>(
+		this HttpClient httpClient,
+		Uri requestUri,
+		TRequest request,
+		JsonTypeInfo<TRequest> requestTypeInfo,
+		JsonTypeInfo<TResponse> responseTypeInfo,
+		CancellationToken cancellationToken = default)
+	{
+		using var response = await httpClient
+			.PatchAsJsonAsync(requestUri, request, requestTypeInfo)
+			.ConfigureAwait(false);
+
+		await response.EnsureSuccessStatusCodeAsync().ConfigureAwait(false);
+		return (await response.Content.ReadFromJsonAsync(responseTypeInfo, cancellationToken).ConfigureAwait(false))!;
 	}
 
 	internal static async Task EnsureSuccessStatusCodeAsync(this HttpResponseMessage response)

--- a/source/VMelnalksnis.PaperlessDotNet/Serialization/PaperlessJsonSerializerContext.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Serialization/PaperlessJsonSerializerContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -19,6 +19,7 @@ namespace VMelnalksnis.PaperlessDotNet.Serialization;
 [JsonSerializable(typeof(PaginatedList<Correspondent>))]
 [JsonSerializable(typeof(Correspondent))]
 [JsonSerializable(typeof(CorrespondentCreation))]
+[JsonSerializable(typeof(CorrespondentUpdate))]
 [JsonSerializable(typeof(PaginatedList<Document>))]
 [JsonSerializable(typeof(Document))]
 [JsonSerializable(typeof(List<PaperlessTask>))]
@@ -30,6 +31,7 @@ namespace VMelnalksnis.PaperlessDotNet.Serialization;
 [JsonSerializable(typeof(PaginatedList<CustomField>))]
 [JsonSerializable(typeof(PaginatedList<Tag>))]
 [JsonSerializable(typeof(TagCreation))]
+[JsonSerializable(typeof(TagUpdate))]
 [JsonSerializable(typeof(DocumentMetadata))]
 [JsonSerializable(typeof(PaginatedList<DocumentType>))]
 [JsonSerializable(typeof(DocumentTypeCreation))]

--- a/source/VMelnalksnis.PaperlessDotNet/Tags/ITagClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Tags/ITagClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -32,6 +32,13 @@ public interface ITagClient
 	/// <param name="tag">The tag to create.</param>
 	/// <returns>The created tag.</returns>
 	Task<Tag> Create(TagCreation tag);
+
+	/// <summary>Updates an existing tag.</summary>
+	/// <param name="id">The id of the tag to update.</param>
+	/// <param name="update">The update to apply.</param>
+	/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+	/// <returns>The updated tag.</returns>
+	Task<Tag> Update(int id, TagUpdate update, CancellationToken cancellationToken = default);
 
 	/// <summary>Deletes a tag.</summary>
 	/// <param name="id">The id of the tag to delete.</param>

--- a/source/VMelnalksnis.PaperlessDotNet/Tags/TagClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Tags/TagClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -58,6 +58,18 @@ public sealed class TagClient : ITagClient
 			tag,
 			_options.GetTypeInfo<TagCreation>(),
 			_options.GetTypeInfo<Tag>());
+	}
+
+	/// <inheritdoc />
+	public async Task<Tag> Update(int id, TagUpdate update, CancellationToken cancellationToken = default)
+	{
+		using var response = await _httpClient
+			.PatchAsJsonAsync(Routes.Tags.IdUri(id), update, _options.GetTypeInfo<TagUpdate>())
+			.ConfigureAwait(false);
+
+		await response.EnsureSuccessStatusCodeAsync().ConfigureAwait(false);
+
+		return (await response.Content.ReadFromJsonAsync(_options.GetTypeInfo<Tag>(), cancellationToken).ConfigureAwait(false))!;
 	}
 
 	/// <inheritdoc />

--- a/source/VMelnalksnis.PaperlessDotNet/Tags/TagClient.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Tags/TagClient.cs
@@ -61,15 +61,14 @@ public sealed class TagClient : ITagClient
 	}
 
 	/// <inheritdoc />
-	public async Task<Tag> Update(int id, TagUpdate update, CancellationToken cancellationToken = default)
+	public Task<Tag> Update(int id, TagUpdate update, CancellationToken cancellationToken = default)
 	{
-		using var response = await _httpClient
-			.PatchAsJsonAsync(Routes.Tags.IdUri(id), update, _options.GetTypeInfo<TagUpdate>())
-			.ConfigureAwait(false);
-
-		await response.EnsureSuccessStatusCodeAsync().ConfigureAwait(false);
-
-		return (await response.Content.ReadFromJsonAsync(_options.GetTypeInfo<Tag>(), cancellationToken).ConfigureAwait(false))!;
+		return _httpClient.PatchAsJsonAsync(
+			Routes.Tags.IdUri(id),
+			update,
+			_options.GetTypeInfo<TagUpdate>(),
+			_options.GetTypeInfo<Tag>(),
+			cancellationToken);
 	}
 
 	/// <inheritdoc />

--- a/source/VMelnalksnis.PaperlessDotNet/Tags/TagUpdate.cs
+++ b/source/VMelnalksnis.PaperlessDotNet/Tags/TagUpdate.cs
@@ -1,0 +1,35 @@
+// Copyright 2022 Valters Melnalksnis
+// Licensed under the Apache License 2.0.
+// See LICENSE file in the project root for full license information.
+
+using VMelnalksnis.PaperlessDotNet.Correspondents;
+
+namespace VMelnalksnis.PaperlessDotNet.Tags;
+
+/// <summary>Information needed to update a <see cref="Tag"/>.</summary>
+public sealed class TagUpdate
+{
+	/// <inheritdoc cref="Tag.Name"/>
+	public string? Name { get; set; }
+
+	/// <summary>Gets or sets the color of the tag in hex format (e.g. <c>#ff0000</c>). API v2 only.</summary>
+	public string? Color { get; set; }
+
+	/// <inheritdoc cref="Tag.Match"/>
+	public string? Match { get; set; }
+
+	/// <inheritdoc cref="Tag.MatchingAlgorithm"/>
+	public MatchingAlgorithm? MatchingAlgorithm { get; set; }
+
+	/// <inheritdoc cref="Tag.IsInsensitive"/>
+	public bool? IsInsensitive { get; set; }
+
+	/// <inheritdoc cref="Tag.IsInboxTag"/>
+	public bool? IsInboxTag { get; set; }
+
+	/// <summary>Gets or sets the id of the parent tag.</summary>
+	public int? Parent { get; set; }
+
+	/// <inheritdoc cref="Tag.Owner"/>
+	public int? Owner { get; set; }
+}

--- a/tests/VMelnalksnis.PaperlessDotNet.Tests.Integration/Correspondents/CorrespondentClientTests.cs
+++ b/tests/VMelnalksnis.PaperlessDotNet.Tests.Integration/Correspondents/CorrespondentClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -65,5 +65,40 @@ public sealed class CorrespondentClientTests(PaperlessFixture paperlessFixture) 
 		{
 			await Client.Correspondents.Delete(correspondent.Id);
 		}
+	}
+
+	[Test]
+	public async Task Update_ShouldUpdateCorrespondent()
+	{
+		var creation = new CorrespondentCreation("Original Company")
+		{
+			Match = "original",
+			MatchingAlgorithm = MatchingAlgorithm.ExactMatch,
+			IsInsensitive = false,
+		};
+
+		var correspondent = await Client.Correspondents.Create(creation);
+
+		var update = new CorrespondentUpdate
+		{
+			Name = "Updated Company",
+			Match = "updated",
+			IsInsensitive = true,
+		};
+
+		var updatedCorrespondent = await Client.Correspondents.Update(correspondent.Id, update);
+
+		using (new AssertionScope())
+		{
+			updatedCorrespondent.Id.Should().Be(correspondent.Id);
+			updatedCorrespondent.Name.Should().Be("Updated Company");
+			updatedCorrespondent.MatchingPattern.Should().Be("updated");
+			updatedCorrespondent.IsInsensitive.Should().BeTrue();
+		}
+
+		var fetched = (await Client.Correspondents.Get(correspondent.Id))!;
+		fetched.Should().BeEquivalentTo(updatedCorrespondent);
+
+		await Client.Correspondents.Delete(correspondent.Id);
 	}
 }

--- a/tests/VMelnalksnis.PaperlessDotNet.Tests.Integration/Tags/TagClientTests.cs
+++ b/tests/VMelnalksnis.PaperlessDotNet.Tests.Integration/Tags/TagClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Valters Melnalksnis
+// Copyright 2022 Valters Melnalksnis
 // Licensed under the Apache License 2.0.
 // See LICENSE file in the project root for full license information.
 
@@ -48,6 +48,38 @@ public sealed class TagClientTests(PaperlessFixture paperlessFixture) : Paperles
 		tags = await Client.Tags.GetAll().ToListAsync();
 
 		tags.Should().NotContainEquivalentOf(createdTag);
+	}
+
+	[Test]
+	public async Task Update_ShouldUpdateTag()
+	{
+		var createdTag = await Client.Tags.Create(new("Original Name")
+		{
+			Match = "original",
+			MatchingAlgorithm = MatchingAlgorithm.ExactMatch,
+		});
+
+		var update = new TagUpdate
+		{
+			Name = "Updated Name",
+			Match = "updated",
+			Color = "#00ff00",
+		};
+
+		var updatedTag = await Client.Tags.Update(createdTag.Id, update);
+
+		using (new AssertionScope())
+		{
+			updatedTag.Id.Should().Be(createdTag.Id);
+			updatedTag.Name.Should().Be("Updated Name");
+			updatedTag.Slug.Should().Be("updated-name");
+			updatedTag.Match.Should().Be("updated");
+		}
+
+		var tag = (await Client.Tags.Get(createdTag.Id))!;
+		tag.Should().BeEquivalentTo(updatedTag, ExcludingDocumentCount);
+
+		await Client.Tags.Delete(createdTag.Id);
 	}
 
 	private static EquivalencyAssertionOptions<Tag> ExcludingDocumentCount(EquivalencyAssertionOptions<Tag> options)


### PR DESCRIPTION
Fixes https://github.com/boexler/PaperlessDotNet/issues/1

## Summary

The Paperless-ngx API supports `PATCH` for both `/api/tags/{id}/` and `/api/correspondents/{id}/`. PaperlessDotNet previously only exposed Get, Create, and Delete for these entities. This PR adds `Update(int id, TUpdate update)` methods, mirroring the existing `DocumentClient.Update` pattern.

## Changes proposed in this pull request

### New DTOs
- **TagUpdate** – Partial update DTO with optional fields: `Name`, `Color` (hex string for API v2), `Match`, `MatchingAlgorithm`, `IsInsensitive`, `IsInboxTag`, `Parent`, `Owner`
- **CorrespondentUpdate** – Partial update DTO with optional fields: `Name`, `Match`, `MatchingAlgorithm`, `IsInsensitive`, `Owner`

### Interface changes
- `ITagClient`: new method `Task<Tag> Update(int id, TagUpdate update, CancellationToken cancellationToken = default)`
- `ICorrespondentClient`: new method `Task<Correspondent> Update(int id, CorrespondentUpdate update, CancellationToken cancellationToken = default)`

### Implementation
- `TagClient.Update` and `CorrespondentClient.Update` call `PatchAsJsonAsync` with the respective route, deserialize the response, and return the updated entity
- Both methods use existing infrastructure: `HttpClientExtensions.PatchAsJsonAsync`, `Routes.Tags.IdUri`, `Routes.Correspondents.IdUri`
- `TagUpdate` and `CorrespondentUpdate` registered in `PaperlessJsonSerializerContext` for source-generated JSON serialization

### Tests
- Integration test `TagClientTests.Update_ShouldUpdateTag`
- Integration test `CorrespondentClientTests.Update_ShouldUpdateCorrespondent`

## Usage example

```csharp
// Update a tag
var update = new TagUpdate
{
    Name = "Updated Name",
    Match = "new-pattern",
    Color = "#00ff00",
};
var updatedTag = await client.Tags.Update(tagId, update);

// Update a correspondent
var update = new CorrespondentUpdate
{
    Name = "Updated Company",
    IsInsensitive = true,
};
var updatedCorrespondent = await client.Correspondents.Update(correspondentId, update);
```

## Notes
- `TagUpdate.Color` uses hex format (e.g. `#ff0000`) for API v2 compatibility; `TagCreation` retains legacy `Colour` (int)
- `Accept: application/json; version=2` is already set in the HttpClient configuration
- All update properties are optional; only provided fields are sent to the API (partial updates via `DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull`)